### PR TITLE
Remove readonly option

### DIFF
--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -41,7 +41,6 @@ func AddNodeFlags(cmd *cobra.Command) {
 
 	// consensus flags
 	cmd.Flags().Bool("consensus.create_empty_blocks", config.Consensus.CreateEmptyBlocks, "Set this to false to only produce blocks when there are txs or when the AppHash changes")
-	cmd.Flags().Bool("consensus.readonly", config.Consensus.Readonly, "Set this to true to make validator skip producing blocks")
 }
 
 // NewRunNodeCmd returns the command that allows the CLI to start a node.

--- a/config/config.go
+++ b/config/config.go
@@ -682,8 +682,6 @@ type ConsensusConfig struct {
 	// Reactor sleep duration parameters
 	PeerGossipSleepDuration     time.Duration `mapstructure:"peer_gossip_sleep_duration"`
 	PeerQueryMaj23SleepDuration time.Duration `mapstructure:"peer_query_maj23_sleep_duration"`
-
-	Readonly bool `mapstructure:"readonly"`
 }
 
 // DefaultConsensusConfig returns a default configuration for the consensus service
@@ -702,7 +700,6 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		CreateEmptyBlocksInterval:   0 * time.Second,
 		PeerGossipSleepDuration:     100 * time.Millisecond,
 		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
-		Readonly:										 false,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -310,9 +310,6 @@ create_empty_blocks_interval = "{{ .Consensus.CreateEmptyBlocksInterval }}"
 peer_gossip_sleep_duration = "{{ .Consensus.PeerGossipSleepDuration }}"
 peer_query_maj23_sleep_duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 
-# Do not produce blocks, just observe (for validator)
-readonly = {{ .Consensus.Readonly }}
-
 ##### transactions indexer configuration options #####
 [tx_index]
 

--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -35,8 +35,6 @@ type Consensus interface {
 	GetLastHeight() int64
 	GetRoundStateJSON() ([]byte, error)
 	GetRoundStateSimpleJSON() ([]byte, error)
-	SetReadonly(readonly bool)
-	IsReadonly() bool
 }
 
 type transport interface {

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -50,6 +50,4 @@ func AddUnsafeRoutes() {
 	Routes["unsafe_start_cpu_profiler"] = rpc.NewRPCFunc(UnsafeStartCPUProfiler, "filename")
 	Routes["unsafe_stop_cpu_profiler"] = rpc.NewRPCFunc(UnsafeStopCPUProfiler, "")
 	Routes["unsafe_write_heap_profile"] = rpc.NewRPCFunc(UnsafeWriteHeapProfile, "filename")
-
-	Routes["set_readonly"] = rpc.NewRPCFunc(SetReadonly, "readonly")
 }

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -3,7 +3,6 @@ package core
 import (
 	"bytes"
 	"time"
-	"strconv"
 
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/p2p"
@@ -112,7 +111,6 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 			Address:     pubKey.Address(),
 			PubKey:      pubKey,
 			VotingPower: votingPower,
-			IsReadonly:	 consensusState.IsReadonly(),
 		},
 	}
 
@@ -143,10 +141,4 @@ func validatorAtHeight(h int64) *types.Validator {
 	}
 
 	return nil
-}
-
-func SetReadonly(ctx *rpctypes.Context, readonly bool) (*ctypes.ResultSetReadonly, error) {
-	consensusState.SetReadonly(readonly)
-
-	return &ctypes.ResultSetReadonly{Log: "Set validator as readonly: " + strconv.FormatBool(readonly)}, nil
 }

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -70,7 +70,6 @@ type ValidatorInfo struct {
 	Address     cmn.HexBytes  `json:"address"`
 	PubKey      crypto.PubKey `json:"pub_key"`
 	VotingPower int64         `json:"voting_power"`
-	IsReadonly  bool					`json:"is_readonly"`
 }
 
 // Node Status
@@ -103,10 +102,6 @@ type ResultDialSeeds struct {
 
 // Log from dialing peers
 type ResultDialPeers struct {
-	Log string `json:"log"`
-}
-
-type ResultSetReadonly struct {
 	Log string `json:"log"`
 }
 


### PR DESCRIPTION
## Description

I mainly went with this diff: https://github.com/tendermint/tendermint/compare/master...leapdao:master and removed all occurrences of the readonly feature.

## TODOs:

- [x] Verify that what I've done here works...

## How I verified this PR

- `make build`
- Took the binary from `build/bin` and copied it into leap-node
- In leapdao/integration-tests, I rebuild using `yarn build`
- Using `yarn test` I ran all integration tests. They passed.