### PR TITLE
fix: CheckBridge ABCI handler receives round number, not height

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -890,7 +890,7 @@ func (cs *ConsensusState) enterPropose(height int64, round int) {
 		logger.Info("enterPropose: Our turn to propose", "proposer", cs.Validators.GetProposer().Address, "privValidator", cs.privValidator)
 
 		if height % 32 == 0 {
-			rsp, err := cs.proxyApp.CheckBridgeSync(abci.RequestCheckBridge{Height: int32(round)})
+			rsp, err := cs.proxyApp.CheckBridgeSync(abci.RequestCheckBridge{Height: int32(height)})
 			if err != nil {
 				logger.Error("Error in proxyAppConn.EndBlock", "err", err)
 				return


### PR DESCRIPTION
From the very beginning of our fork, CheckBridge was supposed to provide the app with
block height ([see](https://github.com/leapdao/tendermint/blob/ac73b47182d5cb018db31f02e49ad0a336f4473f/abci/types/types.proto#L101)].
However, there was always a bug — we were passing in round number (always 0 for enterPropose).

CheckBridge in leap-node worked only because we never really used the passed "height", but rather took it from `chainInfo`. Until April.

Relates leapdao/leap-node#326